### PR TITLE
Fix typo: "Database Svaings Plan" -> "Database Savings Plan"

### DIFF
--- a/src/components/PricingTable.js
+++ b/src/components/PricingTable.js
@@ -127,7 +127,7 @@ function PricingTable({ provisionedPricing, onDemandPricing, formData, selectedR
       onDemandStrong: calculateTotal(onDemandPricing || {}, 'strong'),
       onDemandEventual: calculateTotal(onDemandPricing || {}, 'eventual')
     },
-     { metric: "Monthly total (Database Svaings Plan)", 
+     { metric: "Monthly total (Database Savings Plan)", 
       provisionedStrong: calculateSavingsTotal(provisionedPricing || {}, 'strong'),
       provisionedEventual: calculateSavingsTotal(provisionedPricing || {}, 'eventual'),
       onDemandStrong: calculateSavingsTotal(onDemandPricing || {}, 'strong'),


### PR DESCRIPTION
## Summary
- Corrects the misspelled label "Database Svaings Plan" to "Database Savings Plan" in the pricing table UI (`src/components/PricingTable.js`), shown on the monthly total row under the Savings Plan column.

## Test plan
- [x] Run the app locally and open the pricing calculator
- [ ] Verify the row label now reads "Monthly total (Database Savings Plan)"